### PR TITLE
Fix editing after copying an unwritable cheatsheet to DEFAULT_CHEAT_DIR

### DIFF
--- a/cheat/sheet.py
+++ b/cheat/sheet.py
@@ -25,7 +25,7 @@ def create_or_edit(sheet):
     # if the cheatsheet does not exist
     if not exists(sheet):
         create(sheet)
-    
+
     # if the cheatsheet exists and is writeable...
     elif exists(sheet) and is_writable(sheet):
         edit(sheet)
@@ -41,8 +41,14 @@ def create_or_edit(sheet):
 
         # if yes, copy the cheatsheet to the home directory before editing
         if yes:
-            copy(path(sheet), os.path.join(sheets.default_path(), sheet))
-            edit(sheet)
+            new_sheet_path = os.path.join(sheets.default_path(), sheet)
+            copy(path(sheet), new_sheet_path)
+            # don't call edit() since the cheatsheets cache would return the previous location of the sheet
+            try:
+                subprocess.call([editor(), new_sheet_path])
+
+            except OSError:
+                die('Could not launch ' + editor())
 
         # if no, just abort
         else:


### PR DESCRIPTION
When editing (cheat -e) a unwritable cheatsheet, cheat offers to copy it
to DEFAULT_CHEAT_DIR and edit it there. However, due to the caching of
cheatsheets locations in sheets.cheat
(chrisallenlane/afcaaafbe59c0c24c41ec481a0b0b5cd913fa10f), sheet.edit()
uses the cached location of the sheet instead of the new location, hence
firing up the editor on the unwritable cheatsheet.

I see two ways of fixing this:
* manually fire up the editor on the new (supposedly writable) location
* update or invalidate the sheets.cheat cache and use sheet.edit()

I went the manual-invocation-of-$EDITOR way since it's the most
straightforward for me as a Python noob. Currently it doesn't harm
(apart from breaking a bit of code factorization) since the cache isn't
used after this action (and thus we don't care if it's not up-to-date).
However, it may be more future-proof to invalidate (or better, update)
the cache, as otherwise this bug may bite again some day if an action
that uses the obsolete cache is added after the editing of the new
cheatsheet.