### PR TITLE
ip: better route example

### DIFF
--- a/cheat/cheatsheets/ip
+++ b/cheat/cheatsheets/ip
@@ -19,8 +19,8 @@ ip route
 # Display all routes for IPv6
 ip -6 route
 
-# Add route via gateway IP
-ip route add 192.168.0.0/24 via 192.168.1.1
+# Add default route via gateway IP
+ip route add default via 192.168.1.1
 
 # Add route via interface
 ip route add 192.168.0.0/24 dev eth0


### PR DESCRIPTION
Assigning a subnet is already covered in the example below. Setting a default route via a router is the most common use case of ip route IMHO.