### PR TITLE
Resolves #207

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
 MANIFEST
 build
+cheat.egg-info
 dist

--- a/bin/cheat
+++ b/bin/cheat
@@ -38,7 +38,7 @@ from docopt import docopt
 
 if __name__ == '__main__':
     # parse the command-line options
-    options = docopt(__doc__, version='cheat 2.1.4')
+    options = docopt(__doc__, version='cheat 2.1.5')
 
     # list directories
     if options['--directories']:

--- a/cheat/sheet.py
+++ b/cheat/sheet.py
@@ -32,21 +32,9 @@ def create_or_edit(sheet):
 
     # if the cheatsheet exists but is not writable...
     elif exists(sheet) and not is_writable(sheet):
-        # ... ask the user if we should copy the cheatsheet to her home directory for editing
-        yes = prompt_yes_or_no(
-          'The ' + sheet + ' sheet is not editable. Do you want to copy it to '
-          'your user cheatsheets directory before editing? Keep in mind that '
-          'your sheet will always be used before system-wide one.'
-        )
-
-        # if yes, copy the cheatsheet to the home directory before editing
-        if yes:
-            copy(path(sheet), os.path.join(sheets.default_path(), sheet))
-            edit(sheet)
-
-        # if no, just abort
-        else:
-            die('Aborting.')
+        # copy the cheatsheet to the home directory before editing
+        copy(path(sheet), os.path.join(sheets.default_path(), sheet))
+        edit(sheet)
 
 
 def create(sheet):

--- a/cheat/sheets.py
+++ b/cheat/sheets.py
@@ -2,13 +2,6 @@ from cheat import cheatsheets
 from cheat.utils import *
 import os
 
-# @kludge: it breaks the functional paradigm to a degree, but declaring this
-# var here (versus within get()) gives us a "poor man's" memoization on the
-# call to get(). This, in turn, spares us from having to call out to the
-# filesystem more than once.
-cheats = {}
-
-
 def default_path():
     """ Returns the default cheatsheet path """
 
@@ -37,11 +30,7 @@ def default_path():
 
 def get():
     """ Assembles a dictionary of cheatsheets as name => file-path """
-
-    # if we've already reached out to the filesystem, just return the result
-    # from memory
-    if cheats:
-        return cheats
+    cheats = {}
 
     # otherwise, scan the filesystem
     for cheat_dir in reversed(paths()):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 setup(
     name         = 'cheat',
-    version      = '2.1.4',
+    version      = '2.1.5',
     author       = 'Chris Lane',
     author_email = 'chris@chris-allen-lane.com',
     license      = 'GPL3',


### PR DESCRIPTION
- Solves issue whereby global cheatsheets fail to save after editing

- `cheat` no longer asks a user if a global cheatsheet should be copied
  locally before editing, and instead just silently does so.