### PR TITLE
Issue #180

### DIFF
--- a/bin/cheat
+++ b/bin/cheat
@@ -38,7 +38,7 @@ from docopt import docopt
 
 if __name__ == '__main__':
     # parse the command-line options
-    options = docopt(__doc__, version='cheat 2.1.5')
+    options = docopt(__doc__, version='cheat 2.1.6')
 
     # list directories
     if options['--directories']:

--- a/cheat/sheet.py
+++ b/cheat/sheet.py
@@ -25,14 +25,10 @@ def create_or_edit(sheet):
     # if the cheatsheet does not exist
     if not exists(sheet):
         create(sheet)
-    
-    # if the cheatsheet exists and is writeable...
-    elif exists(sheet) and is_writable(sheet):
-        edit(sheet)
 
-    # if the cheatsheet exists but is not writable...
-    elif exists(sheet) and not is_writable(sheet):
-        # copy the cheatsheet to the home directory before editing
+    # if the cheatsheet exists but not in the default_path, copy it to the
+    # default path before editing
+    elif exists(sheet) and not exists_in_default_path(sheet):
         copy(path(sheet), os.path.join(sheets.default_path(), sheet))
         edit(sheet)
 
@@ -61,6 +57,12 @@ def edit(sheet):
 def exists(sheet):
     """ Predicate that returns true if the sheet exists """
     return sheet in sheets.get() and os.access(path(sheet), os.R_OK)
+
+
+def exists_in_default_path(sheet):
+    """ Predicate that returns true if the sheet exists in default_path"""
+    default_path_sheet = os.path.join(sheets.default_path(), sheet)
+    return sheet in sheets.get() and os.access(default_path_sheet, os.R_OK)
 
 
 def is_writable(sheet):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 setup(
     name         = 'cheat',
-    version      = '2.1.5',
+    version      = '2.1.6',
     author       = 'Chris Lane',
     author_email = 'chris@chris-allen-lane.com',
     license      = 'GPL3',


### PR DESCRIPTION
Now, whenever a cheatsheet is to be edited, if that cheatsheet does not
exist on the `DEFAULT_SHEET_PATH`, it is first copied there before being
opened for editing. This prevents system-wide cheatsheets from being
edited when using `cheat` as `root`.