### PR TITLE
fix typo

### DIFF
--- a/cheat/cheatsheets/wget
+++ b/cheat/cheatsheets/wget
@@ -2,7 +2,7 @@
 wget http://path.to.the/file
 
 # To download a file and change its name
-wget http://path.to.the/file -o newname
+wget http://path.to.the/file -O newname
 
 # To download a file into a directory
 wget -P path/to/directory http://path.to.the/file


### PR DESCRIPTION
reference: 
-O file
--output-document=file
    The documents will not be written to the appropriate files, but all will be concatenated together and
    written to file.  If - is used as file, documents will be printed to standard output, disabling link
    conversion.  (Use ./- to print to a file literally named -.)

    Use of -O is not intended to mean simply "use the name file instead of the one in the URL;" rather,
    it is analogous to shell redirection: wget -O file http://foo is intended to work like wget -O -
    http://foo > file; file will be truncated immediately, and all downloaded content will be written
    there.

    For this reason, -N (for timestamp-checking) is not supported in combination with -O: since file is
    always newly created, it will always have a very new timestamp. A warning will be issued if this
    combination is used.

    Similarly, using -r or -p with -O may not work as you expect: Wget won't just download the first file
    to file and then download the rest to their normal names: all downloaded content will be placed in
    file. This was disabled in version 1.11, but has been reinstated (with a warning) in 1.11.2, as there
    are some cases where this behavior can actually have some use.

    Note that a combination with -k is only permitted when downloading a single document, as in that case
    it will just convert all relative URIs to external ones; -k makes no sense for multiple URIs when
    they're all being downloaded to a single file; -k can be used only when the output is a regular file.