### PR TITLE
Add a golang version to the Related Projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Related Projects
 
 - [`tldr`][tldr]: "Simplified and community-driven man pages".
 
+- [dufferzafar/cheat][5]: An implementation in golang that has syntax highlighting and allows to copy cheats directly to clipboard.
 
 [dotfiles]:  http://dotfiles.github.io/
 [jahendrie]: https://github.com/jahendrie
@@ -150,4 +151,5 @@ Related Projects
 [2]:         https://github.com/jahendrie/cheat
 [3]:         http://errtheblog.com/posts/21-cheat
 [4]:         https://github.com/chrisallenlane/cheat/pull/77
+[5]:         https://github.com/dufferzafar/cheat
 [tldr]:      https://github.com/tldr-pages/tldr


### PR DESCRIPTION
I've created a Go version as means of learning the language. Here's how it looks:

![Screenshot](https://raw.githubusercontent.com/dufferzafar/cheat/master/screenshot.png)

[dufferzafar/cheat](https://github.com/dufferzafar/cheat)