### PR TITLE
Add cheatsheet for command `tree`. Edits or command additions to existing cheatsheets `dd`, `find`, `vim`.

### DIFF
--- a/cheat/cheatsheets/dd
+++ b/cheat/cheatsheets/dd
@@ -17,4 +17,3 @@ dd if=/dev/zero of=/dev/null bs=128M status=progress
 
 # DD with "graphical" return
 dcfldd if=/dev/zero of=/dev/null bs=500K
-

--- a/cheat/cheatsheets/find
+++ b/cheat/cheatsheets/find
@@ -40,5 +40,8 @@ find . -maxdepth 2 -name build -type d
 # To search all files who are not in .git directory
 find . ! -iwholename '*.git*' -type f
 
-# Find all files that have the same node (hard link) as MY_FILE_HERE
+# To find all files that have the same node (hard link) as MY_FILE_HERE
 find . -type f -samefile MY_FILE_HERE 2>/dev/null
+
+# To find all files in the current directory and modify their permissions
+find . -type f -exec chmod 644 {} \;

--- a/cheat/cheatsheets/irssi
+++ b/cheat/cheatsheets/irssi
@@ -16,11 +16,18 @@
 # To switch between channel windows
 ALT+<number>, eg. ALT+1, ALT+2
 
-# To list the nicknames within a channel
+# To list the nicknames within the active channel
 /names
 
-# To change the topic
+# To change the channel topic
 /topic <description>
 
-# To quit irssi
+# To limit channel background noise (joins, parts, quits, etc.)
+/ignore #foo,#bar JOINS PARTS QUITS NICKS   # Quieten only channels `#foo`, `#bar`
+/ignore * JOINS PARTS QUITS NICKS           # Quieten all channels
+
+# To save the current Irssi session config into the configuration file
+/save
+
+# To quit Irssi
 /exit

--- a/cheat/cheatsheets/tree
+++ b/cheat/cheatsheets/tree
@@ -1,0 +1,11 @@
+# To display a recursive directory tree
+tree
+
+# To make tree output contents from path `/foo/bar`
+tree /foo/bar
+
+# To make tree omit any empty directories from the output
+tree --prune
+
+# To list directories only (`-d`), and at a max depth of two levels (`-L`)
+tree -d -L 2

--- a/cheat/cheatsheets/vim
+++ b/cheat/cheatsheets/vim
@@ -23,7 +23,8 @@ B               previous start of whitespace-delimited word
 $               end of line
 gg              go to first line in file
 G               go to end of file
-
+gk		move down one displayed line
+gj		move up one displayed line
 
 # Insertion
 #   To exit from insert mode use Esc or Ctrl-C
@@ -49,8 +50,14 @@ P               paste before cursor
 dd              delete a line
 d{motion}       delete text that {motion} moves over
 
+# Search and replace with the `:substitute` (aka `:s`) command
 
-# Preceding a motion or edition with a number repeats it n times
+:s/foo/bar/	replace the first match of 'foo' with 'bar' on the current line only
+:s/foo/bar/g	replace all matches (`g` flag) of 'foo' with 'bar' on the current line only
+:%s/foo/bar/g	replace all matches of 'foo' with 'bar' in the entire file (`:%s`)
+:%s/foo/bar/gc	ask to manually confirm (`c` flag) each replacement 
+
+# Preceding a motion or edition with a number repeats it 'n' times
 # Examples:
 50k         moves 50 lines up
 2dw         deletes 2 words


### PR DESCRIPTION
There had been no cheatsheet for \`tree\`, so I thought I'd get one started with a couple choice commands. Otherwise, trivial changes to some existing cheatsheets, as well as the addition of new command examples.