### PR TITLE
Use setuptools if possible, add development docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ MANIFEST
 build
 cheat.egg-info
 dist
+venv

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cheat tar
 You will be presented with a cheatsheet resembling:
 
 ```sh
-# To extract an uncompressed archive: 
+# To extract an uncompressed archive:
 tar -xvf '/path/to/foo.tar'
 
 # To extract a .gz archive:
@@ -116,6 +116,27 @@ enable this feature, set a `CHEATCOLORS` environment variable:
 ```sh
 export CHEATCOLORS=true
 ```
+
+Development
+-----------
+
+Virtual environments and `setuptools` can be used to develop `cheat`:
+
+Create a virtual environment with [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/):
+
+    $ virtualenv venv
+
+Activate it:
+
+    $ source venv/bin/activate
+
+Install `cheat` in the venv in [development mode](http://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode):
+
+    $ python setup.py develop
+
+Now `cheat` can be run from inside the venv:
+
+    $ venv/bin/cheat
 
 See Also:
 ---------

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 import os
 
 setup(


### PR DESCRIPTION
- If setuptools is available, use that.
  Setuptools can be very handy in development, because it provides
  `python setup.py develop`.
- Add development documentation, explaining how to use setuptools'
  develop with a virtual environment to work on cheat.
- Backwards compatibility with distutils is maintained.
  If setuptools is not available, distutils will be used.
