### PR TITLE
Support multi-word EDITOR values

### DIFF
--- a/cheat/sheet.py
+++ b/cheat/sheet.py
@@ -1,9 +1,8 @@
 import os
 import shutil
-import subprocess
 
 from cheat import sheets
-from cheat.utils import die, editor
+from cheat.utils import die, open_with_editor
 
 def copy(current_sheet_path, new_sheet_path):
     """ Copies a sheet to a new path """
@@ -39,22 +38,12 @@ def create_or_edit(sheet):
 def create(sheet):
     """ Creates a cheatsheet """
     new_sheet_path = os.path.join(sheets.default_path(), sheet)
-
-    try:
-        subprocess.call([editor(), new_sheet_path])
-
-    except OSError:
-        die('Could not launch ' + editor())
+    open_with_editor(new_sheet_path)
 
 
 def edit(sheet):
     """ Opens a cheatsheet for editing """
-
-    try:
-        subprocess.call([editor(), path(sheet)])
-
-    except OSError:
-        die('Could not launch ' + editor())
+    open_with_editor(path(sheet))
 
 
 def exists(sheet):

--- a/cheat/utils.py
+++ b/cheat/utils.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import os
 import sys
+import subprocess
 
 
 def colorize(sheet_content):
@@ -45,6 +46,16 @@ def editor():
         )
 
     return editor
+
+
+def open_with_editor(filepath):
+    """ Open `filepath` using the EDITOR specified by the environment variables """
+    editor_cmd = editor().split()
+    try:
+        subprocess.call(editor_cmd + [filepath])
+    except OSError:
+        die('Could not launch ' + editor())
+
 
 def warn(message):
     """ Prints a message to stderr """


### PR DESCRIPTION
When the value of EDITOR was more than one words (e.g. emacsclient -c),
it wasn't properly split in an array for subprocess.call and cheat would
fail to launch it.
This commit fixes that.

Closes #301
