### PR TITLE
Unittest

### DIFF
--- a/cheat/sheets.py
+++ b/cheat/sheets.py
@@ -55,8 +55,8 @@ def paths():
     ]
 
     # merge the CHEATPATH paths into the sheet_paths
-    if 'CHEATPATH' in os.environ and os.environ['CHEATPATH']:
-        for path in os.environ['CHEATPATH'].split(os.pathsep):
+    if os.environ.get('CHEATPATH'):
+        for path in os.environ.get('CHEATPATH').split(os.pathsep):
             if os.path.isdir(path):
                 sheet_paths.append(path)
 

--- a/cheat/test/test_sheet.py
+++ b/cheat/test/test_sheet.py
@@ -1,0 +1,82 @@
+from mock import patch
+import os
+from tempfile import mkdtemp
+from unittest import TestCase
+
+from cheat import sheet
+
+
+class TestSheet(TestCase):
+    def setUp(self):
+        self.tmp_dir = mkdtemp()
+
+        self.editor = patch('cheat.sheet.editor').start()
+        self.editor.return_value = 'vim'
+
+        self.die = patch('cheat.sheet.die').start()
+
+        self.builtin_path = os.path.join(self.tmp_dir, 'builtin')
+        os.mkdir(self.builtin_path)
+
+        self.default_path = os.path.join(self.tmp_dir, 'default')
+        os.mkdir(self.default_path)
+        self.sheets_default_path = \
+            patch('cheat.sheet.sheets.default_path').start()
+        self.sheets_default_path.return_value = self.default_path
+
+        self.sheets_paths = patch('cheat.sheet.sheets.paths').start()
+        self.sheets_paths.return_value = [
+            self.default_path, self.builtin_path,
+        ]
+
+        self.subprocess = patch('cheat.sheet.subprocess').start()
+
+    def test_create_or_edit_when_sheet_inexist(self):
+        sheet.create_or_edit('new')
+
+        self.subprocess.call.assert_called_with([
+            'vim', os.path.join(self.default_path, 'new')])
+
+    def test_create_or_edit_when_sheet_inexist_at_default_path(self):
+        cheat_path = os.path.join(self.builtin_path, 'cheat')
+        with open(cheat_path, 'w') as f:
+            f.write((
+                'cheatsheet for cheat\n'
+                'cheat cheat\n'
+            ))
+
+        sheet.create_or_edit('cheat')
+
+        new_cheat_path = os.path.join(self.default_path, 'cheat')
+        self.assertTrue(os.path.exists(new_cheat_path))
+        with open(new_cheat_path, 'r') as f:
+            self.assertEqual(
+                f.read(),
+                ('cheatsheet for cheat\n'
+                 'cheat cheat\n')
+            )
+
+        self.subprocess.call.assert_called_with([
+            'vim', new_cheat_path])
+
+    def test_create_or_edit_when_sheet_exist_at_default_path(self):
+        cheat_path = os.path.join(self.default_path, 'cheat')
+        open(cheat_path, 'w').close()
+
+        sheet.create_or_edit('cheat')
+        self.subprocess.call.assert_called_with([
+            'vim', cheat_path])
+
+    def test_read(self):
+        cheat_path = os.path.join(self.builtin_path, 'cheat')
+        with open(cheat_path, 'w') as f:
+            f.write((
+                'cheatsheet for cheat\n'
+                'cheat cheat\n'
+            ))
+
+        self.assertEqual(
+            sheet.read('cheat'),
+            ('cheatsheet for cheat\n'
+             'cheat cheat\n')
+        )

--- a/cheat/test/test_sheets.py
+++ b/cheat/test/test_sheets.py
@@ -1,0 +1,189 @@
+from mock import patch
+import os
+from tempfile import mkdtemp
+from unittest import TestCase
+
+from cheat import cheatsheets
+from cheat.sheets import (
+    default_path, paths, get,
+)
+
+
+class TestSheets(TestCase):
+    def setUp(self):
+        self.tmp_dir = mkdtemp()
+
+    def _make_sheets(self, sheets):
+        for sheet in sheets:
+            dir_, file_ = os.path.split(sheet)
+            if not os.path.exists(dir_):
+                os.mkdir(dir_)
+            open(sheet, 'w').close()
+
+    @patch('cheat.sheets.os.environ.get')
+    def test_default_path_via_env(self, mock_environ_get):
+        mock_environ_get.return_value = self.tmp_dir
+
+        path = default_path()
+
+        self.assertEqual(path, self.tmp_dir)
+
+    @patch('cheat.sheets.os.environ.get')
+    def test_default_path_via_env_unexists(self, mock_environ_get):
+        os.rmdir(self.tmp_dir)
+        mock_environ_get.return_value = self.tmp_dir
+
+        path = default_path()
+
+        self.assertEqual(path, self.tmp_dir)
+        os.path.isdir(self.tmp_dir)
+
+    @patch('cheat.sheets.os.path.expanduser')
+    @patch('cheat.sheets.os.environ.get')
+    def test_default_path_from_home(self, mock_environ_get, mock_expanduser):
+        mock_environ_get.return_value = None
+        mock_expanduser.return_value = self.tmp_dir
+        os.mkdir(os.path.join(self.tmp_dir, '.cheat'))
+
+        path = default_path()
+
+        self.assertEqual(path, os.path.join(self.tmp_dir, '.cheat'))
+
+    @patch('cheat.sheets.os.path.expanduser')
+    @patch('cheat.sheets.os.environ.get')
+    def test_default_path_from_home_not_exists(
+            self, mock_environ_get, mock_expanduser):
+        mock_environ_get.return_value = None
+        mock_expanduser.return_value = self.tmp_dir
+
+        path = default_path()
+
+        self.assertEqual(path, os.path.join(self.tmp_dir, '.cheat'))
+        os.path.isdir(os.path.join(self.tmp_dir, '.cheat'))
+
+    @patch('cheat.sheets.die')
+    @patch('cheat.sheets.os.environ.get')
+    def test_default_path_unreadable(self, mock_environ_get, mock_die):
+        mock_environ_get.return_value = self.tmp_dir
+        os.chmod(self.tmp_dir, int('333', 8))
+
+        default_path()
+
+        mock_die.assert_called_with(
+            'The DEFAULT_CHEAT_DIR (%s) is not readable.' % self.tmp_dir)
+
+    @patch('cheat.sheets.die')
+    @patch('cheat.sheets.os.environ.get')
+    def test_default_path_untouchable(self, mock_environ_get, mock_die):
+        mock_environ_get.return_value = self.tmp_dir
+        os.chmod(self.tmp_dir, int('555', 8))
+
+        default_path()
+
+        mock_die.assert_called_with(
+            'The DEFAULT_CHEAT_DIR (%s) is not writable.' % self.tmp_dir)
+
+    @patch('cheat.sheets.default_path')
+    @patch('cheat.sheets.os.environ.get')
+    def test_paths_only_default(self, mock_environ_get, mock_default_path):
+        mock_environ_get.return_value = None
+        mock_default_path.return_value = self.tmp_dir
+
+        result = paths()
+
+        self.assertEqual(result, [self.tmp_dir, cheatsheets.sheets_dir()[0]])
+
+    @patch('cheat.sheets.default_path')
+    @patch('cheat.sheets.os.environ.get')
+    def test_paths_with_additonal_definition(
+            self, mock_environ_get, mock_default_path):
+        additonal_paths = [
+            os.path.join(self.tmp_dir, 'path1'),
+            os.path.join(self.tmp_dir, 'path2'),
+        ]
+        for path in additonal_paths:
+            os.mkdir(path)
+        mock_environ_get.return_value = os.pathsep.join(additonal_paths)
+        mock_default_path.return_value = self.tmp_dir
+
+        result = paths()
+
+        self.assertEqual(
+                result,
+                [self.tmp_dir, cheatsheets.sheets_dir()[0]] +
+                additonal_paths)
+
+    @patch('cheat.sheets.paths')
+    def test_get(self, mock_paths):
+        self._make_sheets([
+            os.path.join(self.tmp_dir, 'cheatdir1', 'curl'),
+            os.path.join(self.tmp_dir, 'cheatdir1', 'http'),
+            os.path.join(self.tmp_dir, 'cheatdir2', 'tar'),
+            os.path.join(self.tmp_dir, 'cheatdir2', 'zip'),
+        ])
+        mock_paths.return_value = [
+            os.path.join(self.tmp_dir, 'cheatdir1'),
+            os.path.join(self.tmp_dir, 'cheatdir2'),
+        ]
+
+        cheats = get()
+        self.assertEqual(
+            cheats,
+            {
+                'curl': os.path.join(self.tmp_dir, 'cheatdir1', 'curl'),
+                'http': os.path.join(self.tmp_dir, 'cheatdir1', 'http'),
+                'tar': os.path.join(self.tmp_dir, 'cheatdir2', 'tar'),
+                'zip': os.path.join(self.tmp_dir, 'cheatdir2', 'zip'),
+            }
+        )
+
+    @patch('cheat.sheets.paths')
+    def test_get_with_duplicate_cheat(self, mock_paths):
+        self._make_sheets([
+            os.path.join(self.tmp_dir, 'cheatdir1', 'curl'),
+            os.path.join(self.tmp_dir, 'cheatdir1', 'http'),
+            os.path.join(self.tmp_dir, 'cheatdir2', 'tar'),
+            os.path.join(self.tmp_dir, 'cheatdir2', 'zip'),
+            os.path.join(self.tmp_dir, 'cheatdir2', 'http'),
+        ])
+        mock_paths.return_value = [
+            os.path.join(self.tmp_dir, 'cheatdir1'),
+            os.path.join(self.tmp_dir, 'cheatdir2'),
+        ]
+
+        cheats = get()
+        self.assertEqual(
+            cheats,
+            {
+                'curl': os.path.join(self.tmp_dir, 'cheatdir1', 'curl'),
+                'http': os.path.join(self.tmp_dir, 'cheatdir1', 'http'),
+                'tar': os.path.join(self.tmp_dir, 'cheatdir2', 'tar'),
+                'zip': os.path.join(self.tmp_dir, 'cheatdir2', 'zip'),
+            }
+        )
+
+    @patch('cheat.sheets.paths')
+    def test_get_with_exclude_pattern(self, mock_paths):
+        self._make_sheets([
+            os.path.join(self.tmp_dir, 'cheatdir1', 'curl'),
+            os.path.join(self.tmp_dir, 'cheatdir1', 'http'),
+            os.path.join(self.tmp_dir, 'cheatdir1', '__init__.py'),
+            os.path.join(self.tmp_dir, 'cheatdir2', 'tar'),
+            os.path.join(self.tmp_dir, 'cheatdir2', 'zip'),
+            os.path.join(self.tmp_dir, 'cheatdir2', '.git'),
+        ])
+        mock_paths.return_value = [
+            os.path.join(self.tmp_dir, 'cheatdir1'),
+            os.path.join(self.tmp_dir, 'cheatdir2'),
+        ]
+
+        cheats = get()
+        self.assertEqual(
+            cheats,
+            {
+                'curl': os.path.join(self.tmp_dir, 'cheatdir1', 'curl'),
+                'http': os.path.join(self.tmp_dir, 'cheatdir1', 'http'),
+                'tar': os.path.join(self.tmp_dir, 'cheatdir2', 'tar'),
+                'zip': os.path.join(self.tmp_dir, 'cheatdir2', 'zip'),
+            }
+        )

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,10 @@ setup(
     install_requires = [
         'docopt >= 0.6.1',
         'pygments >= 1.6.0',
-    ]
+    ],
+    extras_require   = {
+        'dev': [
+            'mock == 2.0.0',
+        ]
+    }
 )


### PR DESCRIPTION
refs: #17

Simply implement the unit test for cheat that just cover some happy path or major logic like cheat path ordering, cheatsheet exists or not, etc...

I used built-in unit test tool to test on it.
```python -munittest discover```
pytest or something else testing module is fine too~

If there is anything that I can help or need improved, please tell me, thanks.