### PR TITLE
Added support for `~` and environment variables in `DEFAULT_CHEAT_DIR`

### DIFF
--- a/cheat/sheets.py
+++ b/cheat/sheets.py
@@ -7,7 +7,8 @@ def default_path():
     """ Returns the default cheatsheet path """
 
     # determine the default cheatsheet dir
-    default_sheets_dir = os.environ.get('DEFAULT_CHEAT_DIR') or os.path.join(os.path.expanduser('~'), '.cheat')
+    default_sheets_dir = os.environ.get('DEFAULT_CHEAT_DIR') or os.path.join('~', '.cheat')
+    default_sheets_dir = os.path.expanduser(os.path.expandvars(default_sheets_dir))
 
     # create the DEFAULT_CHEAT_DIR if it does not exist
     if not os.path.isdir(default_sheets_dir):


### PR DESCRIPTION
If the `DEFAULT_CHEAT_DIR` environment variable contains the `~` — as shortcut for the users home directory — or environment variables like `$HOME`, the program bails. This change allows the usage of both.