### PR TITLE
Updated pip sheet with upgrade for newer versions

### DIFF
--- a/cheat/cheatsheets/pip
+++ b/cheat/cheatsheets/pip
@@ -23,5 +23,8 @@ pip list --outdated
 # Upgrade all outdated packages, thanks to http://stackoverflow.com/a/3452888
 pip freeze --local | grep -v '^\-e' | cut -d = -f 1 | xargs -n1 pip install -U
 
+# Upgrade outdated packages on latest version of pip
+pip list --outdated --format=freeze | cut -d = -f 1 | xargs -n1 pip install -U
+
 # Install specific version of a package
 pip install -I SomePackage1==1.1.0 'SomePackage2>=1.0.4'


### PR DESCRIPTION
Since newer versions of `pip` allow `pip list --outdated`, the upgrade script could be updated.