### PR TITLE
fix crontab command

### DIFF
--- a/cheat/cheatsheets/crontab
+++ b/cheat/cheatsheets/crontab
@@ -16,7 +16,7 @@ SHELL=/bin/bash
 */15 * * * * /home/user/command.sh
 
 # every midnight
-* 0 * * * /home/user/command.sh
+0 0 * * * /home/user/command.sh
 
 # every Saturday at 8:05 AM
 5 8 * * 6 /home/user/command.sh


### PR DESCRIPTION
Hi, I test the crontab command that run job every midnight on my Mac and Ubuntu, 
`* 0 * * * /home/user/command.sh` this will run every minute at 0 o'clock, 
So i think it should be `0 0 * * * /home/user/command.sh`.