### PR TITLE
Add cheatsheet slurm

### DIFF
--- a/cheat/cheatsheets/slurm
+++ b/cheat/cheatsheets/slurm
@@ -1,0 +1,15 @@
+# Submit a new job:
+sbatch job.sh
+
+# List all jobs for a user:
+squeue -u user_name
+
+# Cancel a job by id or name:
+scancel job_id
+scancel --name job_name
+
+# List all information for a job:
+scontrol show jobid -dd job_id
+
+# Status info for currently running job:
+sstat --format=AveCPU,AvePages,AveRSS,AveVMSize,JobID -j job_id --allsteps


### PR DESCRIPTION
Not sure if this is a proper way of doing this but slurm has a collection of commands that are all used together to control the jobs. So my initial idea was to create just a cheatsheet for slurm which contains most commonly used and useful commands. I have tried to keep it minimal and short.