### PR TITLE
Disable colorized output when CHEATCOLORS is not "true", or not set

### DIFF
--- a/cheat/utils.py
+++ b/cheat/utils.py
@@ -8,7 +8,7 @@ def colorize(sheet_content):
     """ Colorizes cheatsheet content if so configured """
 
     # only colorize if so configured
-    if not 'CHEATCOLORS' in os.environ:
+    if not 'CHEATCOLORS' in os.environ or os.environ.get('CHEATCOLORS') != 'true':
         return sheet_content
 
     try:


### PR DESCRIPTION
Minor fix to address an issue where output was colorized even when CHEATCOLORS is set to false (or any value not "true").
Tested successfully with python 2.7.5 and 3.7.1.