### PR TITLE
Fix url in curl cheatsheet

### DIFF
--- a/cheat/cheatsheets/curl
+++ b/cheat/cheatsheets/curl
@@ -29,7 +29,7 @@ curl -C - -o partial_file.zip http://example.com/file.zip
 curl -I http://example.com
 
 # Fetch your external IP and network info as JSON
-curl http://ifconfig.me/all/json
+curl http://ifconfig.me/all.json
 
 # Limit the rate of a download
 curl --limit-rate 1000B -O http://path.to.the/file


### PR DESCRIPTION
http://ifconfig.me/all/json response is:
```
{
  "error": {
    "title": "Wrong ip",
    "message": "Please provide a valid IP address"
  }
}
```

Correct url is http://ifconfig.me/all.json