### PR TITLE
bugfix: UnicodeEncodeError: 'ascii' codec can't encode character u'\x…

### DIFF
--- a/cheat/sheet.py
+++ b/cheat/sheet.py
@@ -72,5 +72,5 @@ def read(sheet):
     if not exists(sheet):
         die('No cheatsheet found for ' + sheet)
 
-    with open(path(sheet)) as cheatfile:
+    with open(path(sheet), encoding='ascii', errors='ignore') as cheatfile:
         return cheatfile.read()

--- a/cheat/sheets.py
+++ b/cheat/sheets.py
@@ -84,7 +84,7 @@ def search(term):
 
     for cheatsheet in sorted(get().items()):
         match = ''
-        for line in open(cheatsheet[1]):
+        for line in open(cheatsheet[1], encoding='ascii', errors='ignore'):
             if term in line:
                 match += '  ' + highlight(term, line)
 


### PR DESCRIPTION
@chrisallenlane : this PR fixes the encoding issue with:

* listing the cheatsheet for find: `cheat find` - see [https://github.com/chrisallenlane/cheat/issues/372](https://github.com/chrisallenlane/cheat/issues/372).
* searching for a word in cheatsheets: `cheat -s "mysearch"` 

I tested it with the snap version and there it seems to work fine.

**ISSUE:**
This bug only comes to live when activating colored output (CHEATCOLORS=true)
1) calling `cheat find` you currently get an ```UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 331: ordinal not in range(128)```
2) searching for a word in all cheatsheets `cheat -s "mysearch"` you currently get an ```UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 331: ordinal not in range(128)```

**FIX:**
The fix is to open the sheet files with ascii encoding and ignore encoding errors.

**EXPECTED:**
`export CHEATCOLORS=true; 
cheat find` 
opens without errors
`cheat -s "mysearch"`