### PR TITLE
Issue #406

### DIFF
--- a/cheat/utils.py
+++ b/cheat/utils.py
@@ -11,6 +11,10 @@ def colorize(sheet_content):
     if not 'CHEATCOLORS' in os.environ:
         return sheet_content
 
+    # don't attempt to colorize an empty cheatsheet
+    if not sheet_content.strip():
+        return ""
+
     try:
         from pygments import highlight
         from pygments.lexers import get_lexer_by_name


### PR DESCRIPTION
Attempting to resolve issue #406.

As best as I can tell, the issue manifests when the `colorize` method is
applied to an empty cheatsheet content, which will occur when a search
returns no results.

This patch simply tests to see if search results are empty, and returns
early if so.