### PR TITLE
Issue #414 - snap package compatibility

### DIFF
--- a/cheat/sheets.py
+++ b/cheat/sheets.py
@@ -63,7 +63,6 @@ class Sheets:
         """ Assembles a list of directories containing cheatsheets """
         sheet_paths = [
             self.default_path(),
-            '/usr/share/cheat',
         ]
 
         # merge the CHEATPATH paths into the sheet_paths

--- a/config/cheat
+++ b/config/cheat
@@ -1,1 +1,5 @@
-{"CHEAT_COLORS":true,"CHEAT_EDITOR":"vi"}
+{
+  "CHEAT_COLORS": true,
+  "CHEAT_EDITOR":"vi",
+  "CHEAT_PATH":"/usr/share/cheat"
+}

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,17 @@
 from distutils.core import setup
 import os
 
+# determine the directory in which to install system-wide cheatsheets
+# KLUDGE: It would be better to read `/usr/share/cheat` from `config/cheat`
+# rather than hard-coding it here
+cheat_path = os.environ.get('CHEAT_PATH') or '/usr/share/cheat'
+
+# aggregate the systme-wide cheatsheets
 cheat_files = []
 for f in os.listdir('cheat/cheatsheets/'):
     cheat_files.append(os.path.join('cheat/cheatsheets/',f))
 
+# specify build params
 setup(
     name         = 'cheat',
     version      = '2.3.1',
@@ -26,7 +33,7 @@ setup(
         'pygments >= 1.6.0',
     ],
     data_files = [
-        ('/usr/share/cheat', cheat_files),
+        (cheat_path, cheat_files),
         ('/etc', ['config/cheat']),
     ],
 )


### PR DESCRIPTION
PR #391 changed the locaton into which system-wide cheatsheets are
installed to `/usr/share/cheat`, in order to comply with FHS. However,
this is causing conflicts with the `snap` packaging process.

This commit removes hard-coded references to `/usr/share/cheat` (outside
of `config/cheat`), and instead reads the cheat path via the
`CHEAT_PATH` config value (which may be set either in `cheat/config`, or
exported as an environment variable).

Lastly, this commit makes `setup.py` "aware of" the `CHEAT_PATH` env
var, allowing us to specify to where sytem-wide cheatsheets should be
installed during the `snap` build.