### PR TITLE
Added termcolor dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     install_requires = [
         'docopt >= 0.6.1',
         'pygments >= 1.6.0',
+        'termcolor >= 1.1.0',
     ],
     data_files = [
         (cheat_path, cheat_files),


### PR DESCRIPTION
Added a missing `termcolor` dependency to `install_requires` in
`setup.py`. `termcolors` was introduced as an optional dependency when
the `CHEAT_HIGHLIGHT` envvar was implemented.